### PR TITLE
DiffEditorDidMount-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ You can play with it [here](https://codesandbox.io/s/monaco-editorreact---contro
 | language | enum: ... | | All languages that are [supported](https://github.com/microsoft/monaco-languages) by monaco-editor |
 | originalLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the `original` source separately, otherwise, it will get the value of `language` property. (Possible values are the same as `language`) |
 | modifiedLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the `modified` source separately, otherwise, it will get the value of `language` property. (Possible values are the same as `language`) |
-| editorDidMount | func | noop | **Signature: function(getOriginalEditorValue: func, getModifiedEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a third argument |
+| editorDidMount | func | noop | **Signature: function(getModifiedEditorValue: func, getOriginalEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a third argument |
 | theme | enum: 'light' \| 'dark' | 'light' | Default themes of monaco |
 | width | union: number \| string | '100%' | The width of the editor wrapper |
 | height | union: number \| string | '100%' | The height of the editor wrapper |

--- a/demo/src/config/diff.js
+++ b/demo/src/config/diff.js
@@ -102,7 +102,7 @@ const examples = {
     | language | enum: ... | | All languages that are [supported](https://github.com/microsoft/monaco-languages) by monaco-editor |
     | originalLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the \`original\` source separately, otherwise, it will get the value of \`language\` property. (Possible values are the same as \`language\`) |
     | modifiedLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the \`modified\` source separately, otherwise, it will get the value of \`language\` property. (Possible values are the same as \`language\`) |
-    | editorDidMount | func | noop | **Signature: function(getOriginalEditorValue: func, getModifiedEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor will be mounted and ready to work. It will get the editor instance as a third argument |
+    | editorDidMount | func | noop | **Signature: function(getModifiedEditorValue: func, getOriginalEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor will be mounted and ready to work. It will get the editor instance as a third argument |
     | theme | enum: 'light' \| 'dark' | 'light' | Default themes of monaco |
     | line | number |  | The line to jump on it |
     | width | union: number \| string | '100%' | The width of the editor wrapper |
@@ -486,7 +486,7 @@ const examples = {
     | language | enum: ... | | All languages that are [supported](https://github.com/microsoft/monaco-languages) by monaco-editor |
     | originalLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the \`original\` source separately, otherwise, it will get the value of \`language\` property. (Possible values are the same as \`language\`) |
     | modifiedLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the \`modified\` source separately, otherwise, it will get the value of \`language\` property. (Possible values are the same as \`language\`) |
-    | editorDidMount | func | noop | **Signature: function(getOriginalEditorValue: func, getModifiedEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a third argument |
+    | editorDidMount | func | noop | **Signature: function(getModifiedEditorValue: func, getOriginalEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a third argument |
     | theme | enum: 'light' \| 'dark' | 'light' | Default themes of monaco |
     | line | number |  | The line to jump on it |
     | width | union: number \| string | '100%' | The width of the editor wrapper |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,8 +92,8 @@ export { ControlledEditor };
 // Diff Editor
 
 export type DiffEditorDidMount = (
-  getOriginalEditorValue: () => string,
   getModifiedEditorValue: () => string,
+  getOriginalEditorValue: () => string,
   editor: monacoEditor.editor.IStandaloneDiffEditor,
 ) => void;
 
@@ -128,7 +128,7 @@ export interface DiffEditorProps {
   modifiedLanguage?: string;
 
   /**
-   * Signature: function(getOriginalEditorValue: func, getModifiedEditorValue: func, editor: object) => void
+   * Signature: function(getModifiedEditorValue: func, getOriginalEditorValue: func, editor: object) => void
    * This function will be called right after monaco editor will be mounted and ready to work.
    * It gets the editor instance as a third argument
    */


### PR DESCRIPTION
The definition of `DiffEditorDidMount` is defined as
```
export type DiffEditorDidMount = (
  getOriginalEditorValue: () => string,
  getModifiedEditorValue: () => string,
  editor: monacoEditor.editor.IStandaloneDiffEditor,
) => void;
```

but in [the implementation](https://github.com/suren-atoyan/monaco-react/blob/master/src/DiffEditor/DiffEditor.js#L84), getOriginalEditorValue and getModifiedEditorValue are swapped.

I propose to simply update the type definition for `DiffEditorDidMount` and the README rather than change the implementation which would introduce breaking changes.