### PR TITLE
Changed order of 'options' and 'value' effects in Editor component

### DIFF
--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -28,6 +28,10 @@ const Editor =
   });
 
   useUpdate(_ => {
+    editorRef.current.updateOptions(options);
+  }, [options], isEditorReady);
+
+  useUpdate(_ => {
     if (options.readOnly) {
       editorRef.current.setValue(value);
     } else {
@@ -59,10 +63,6 @@ const Editor =
   useUpdate(_ => {
     monacoRef.current.editor.setTheme(theme);
   }, [theme], isEditorReady);
-
-  useUpdate(_ => {
-    editorRef.current.updateOptions(options);
-  }, [options], isEditorReady);
 
   const createEditor = useCallback(_ => {
     editorRef.current = monacoRef.current.editor.create(containerRef.current, {

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -32,7 +32,7 @@ const Editor =
   }, [options], isEditorReady);
 
   useUpdate(_ => {
-    if (options.readOnly) {
+    if (editorRef.current.getOption(monacoRef.current.editor.EditorOption.readOnly)) {
       editorRef.current.setValue(value);
     } else {
       editorRef.current.executeEdits('', [{


### PR DESCRIPTION
Hi! First of all, thanks for great library.

I found a bug which occurs when we want to switch the Editor component state from read-only mode showing some contents to editing mode with empty editor. If you switch `readOnly` property from `true` to `false` and set `value` to empty string, new value is not correctly applied.

That's due to the order of useUpdate's in Editor component. If I understand the code correctly: Editor component is using `executeEdits` in non-readOnly mode to keep the undo stack. This function doesn't work in readOnly mode, so in the opposite case - `setValue` is used instead. 

Unfortunately, in current effect order, if we change both properties simultaneously:  `options.readOnly` is `false` but editor itself is not switched yet to the non-readOnly state, so `executeEdits` doesn't update the value. Changing the order of both effects fixes that issue.