### PR TITLE
Add overrides prop to editor

### DIFF
--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -9,7 +9,7 @@ import { useMount, useUpdate } from '../utils/hooks';
 import themes from '../config/themes';
 
 const Editor =
-  ({ value, language, editorDidMount, theme, line, width, height, loading, options, overrides, _isControlledMode }) =>
+  ({ value, language, editorDidMount, theme, line, width, height, loading, options, overrideServices, _isControlledMode }) =>
 {
   const [isEditorReady, setIsEditorReady] = useState(false);
   const [isMonacoMounting, setIsMonacoMounting] = useState(true);
@@ -70,7 +70,7 @@ const Editor =
       language,
       automaticLayout: true,
       ...options,
-    }, overrides);
+    }, overrideServices);
 
     editorDidMount(editorRef.current.getValue.bind(editorRef.current), editorRef.current);
 
@@ -78,7 +78,7 @@ const Editor =
     monacoRef.current.editor.setTheme(theme);
 
     setIsEditorReady(true);
-  }, [editorDidMount, language, options, overrides, theme, value]);
+  }, [editorDidMount, language, options, overrideServices, theme, value]);
 
   useEffect(_ => {
     !isMonacoMounting && !isEditorReady && createEditor();
@@ -105,7 +105,7 @@ Editor.propTypes = {
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   loading: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.object,
-  overrides: PropTypes.object,
+  overrideServices: PropTypes.object,
   _isControlledMode: PropTypes.bool,
 };
 
@@ -116,7 +116,7 @@ Editor.defaultProps = {
   height: '100%',
   loading: 'Loading...',
   options: {},
-  overrides: {},
+  overrideServices: {},
   _isControlledMode: false,
 };
 

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -9,7 +9,7 @@ import { useMount, useUpdate } from '../utils/hooks';
 import themes from '../config/themes';
 
 const Editor =
-  ({ value, language, editorDidMount, theme, line, width, height, loading, options, _isControlledMode }) =>
+  ({ value, language, editorDidMount, theme, line, width, height, loading, options, overrides, _isControlledMode }) =>
 {
   const [isEditorReady, setIsEditorReady] = useState(false);
   const [isMonacoMounting, setIsMonacoMounting] = useState(true);
@@ -70,7 +70,7 @@ const Editor =
       language,
       automaticLayout: true,
       ...options,
-    });
+    }, overrides);
 
     editorDidMount(editorRef.current.getValue.bind(editorRef.current), editorRef.current);
 
@@ -78,7 +78,7 @@ const Editor =
     monacoRef.current.editor.setTheme(theme);
 
     setIsEditorReady(true);
-  }, [editorDidMount, language, options, theme, value]);
+  }, [editorDidMount, language, options, overrides, theme, value]);
 
   useEffect(_ => {
     !isMonacoMounting && !isEditorReady && createEditor();
@@ -105,6 +105,7 @@ Editor.propTypes = {
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   loading: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.object,
+  overrides: PropTypes.object,
   _isControlledMode: PropTypes.bool,
 };
 
@@ -115,6 +116,7 @@ Editor.defaultProps = {
   height: '100%',
   loading: 'Loading...',
   options: {},
+  overrides: {},
   _isControlledMode: false,
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,7 +66,7 @@ export interface EditorProps {
   /**
    * IEditorOverrideServices
    */
-  overrides?: monacoEditor.editor.IEditorOverrideServices;
+  overrideServices?: monacoEditor.editor.IEditorOverrideServices;
 }
 
 declare const Editor: React.FC<EditorProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,6 +62,11 @@ export interface EditorProps {
    * IEditorConstructionOptions
    */
   options?: monacoEditor.editor.IEditorConstructionOptions;
+
+  /**
+   * IEditorOverrideServices
+   */
+  overrides?: monacoEditor.editor.IEditorOverrideServices;
 }
 
 declare const Editor: React.FC<EditorProps>;


### PR DESCRIPTION
Hi -- thanks for your work and the useful library!

I ran into the same issue raised in #79, wanting to add support for `go to definition` functionality. Since we also needed this change and you mentioned intending to add it in the next version, I thought I would make a PR to help make this easier.

In order to support this we need to pass the `overrides` object into the `editor.create` call. I added it as a prop to the `Editor` component and pass it through to the create call. With this change we can override the `CodeEditorService` and add custom handling.

Thanks and let me know if there are any other changes I am missing.