### PR TITLE
Exposes the monaco instance through `editorDidMount`

### DIFF
--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -85,7 +85,7 @@ const Editor = ({
       ...options,
     }, overrideServices);
 
-    editorDidMount(editorRef.current.getValue.bind(editorRef.current), editorRef.current);
+    editorDidMount(editorRef.current.getValue.bind(editorRef.current), editorRef.current, monacoRef.current);
 
     monacoRef.current.editor.defineTheme('dark', themes['night-dark']);
     monacoRef.current.editor.setTheme(theme);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,7 @@ type Theme =
 export type EditorDidMount = (
   getEditorValue: () => string,
   editor: monacoEditor.editor.IStandaloneCodeEditor,
+  monaco: typeof monacoEditor,
 ) => void;
 
 export interface EditorProps {


### PR DESCRIPTION
Cf rational here:

https://github.com/suren-atoyan/monaco-react/issues/56#issuecomment-657675803

Basically, directly exposing the monaco instance in this area makes the code flow less ambiguous and more predictable.