### PR TITLE
Add id attribute prop to editor component

### DIFF
--- a/src/DiffEditor/DiffEditor.js
+++ b/src/DiffEditor/DiffEditor.js
@@ -10,6 +10,7 @@ import themes from '../config/themes';
 
 const DiffEditor =
   ({
+    id,
     original,
     modified,
     language,
@@ -103,6 +104,7 @@ const DiffEditor =
   const disposeEditor = _ => editorRef.current.dispose();
 
   return <MonacoContainer
+    containerId={id}
     width={width}
     height={height}
     isEditorReady={isEditorReady}
@@ -114,6 +116,7 @@ const DiffEditor =
 };
 
 DiffEditor.propTypes = {
+  id: PropTypes.string,
   original: PropTypes.string,
   modified: PropTypes.string,
   language: PropTypes.string,

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -9,6 +9,7 @@ import { useMount, useUpdate } from '../hooks';
 import themes from '../config/themes';
 
 const Editor = ({
+  id,
   value,
   language,
   editorDidMount,
@@ -102,6 +103,7 @@ const Editor = ({
   const disposeEditor = _ => editorRef.current.dispose();
 
   return <MonacoContainer
+    containerId={id}
     width={width}
     height={height}
     isEditorReady={isEditorReady}
@@ -113,6 +115,7 @@ const Editor = ({
 };
 
 Editor.propTypes = {
+  id:PropTypes.string,
   value: PropTypes.string,
   language: PropTypes.string,
   editorDidMount: PropTypes.func,

--- a/src/MonacoContainer/MonacoContainer.js
+++ b/src/MonacoContainer/MonacoContainer.js
@@ -9,6 +9,7 @@ import styles from './styles';
 // one of the reasons why we use a separate prop for passing ref instead of using forwardref
 
 const MonacoContainer = ({
+  containerId,
   width,
   height,
   isEditorReady,
@@ -17,7 +18,7 @@ const MonacoContainer = ({
   className,
   wrapperClassName,
 }) => (
-  <section style={{ ...styles.wrapper, width, height }} className={wrapperClassName}>
+  <section id={containerId} style={{ ...styles.wrapper, width, height }} className={wrapperClassName}>
     {!isEditorReady && <Loading content={loading} />}
     <div
       ref={_ref}
@@ -33,6 +34,7 @@ MonacoContainer.propTypes = {
   loading: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   isEditorReady: PropTypes.bool.isRequired,
   className: PropTypes.string,
+  containerId: PropTypes.string,
   wrapperClassName: PropTypes.string,
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,10 @@ export type EditorDidMount = (
 
 export interface EditorProps {
   /**
+   * The editor component HTML document id value
+   */
+  id?:string | null;
+  /**
    * The editor value
    */
   value?: string | null;
@@ -103,6 +107,10 @@ export type DiffEditorDidMount = (
 ) => void;
 
 export interface DiffEditorProps {
+  /**
+   * The editor component HTML document id value
+   */
+  id?: string | null;
   /**
    * The original source (left one) value
    */


### PR DESCRIPTION
I was trying to access the editor using `document.getElementById()` but there was no attribute id given to the editor due to which I was always getting a `null` value. I have therefore added an attribute id which will give the access of the Monaco editor as element from HTML document.