### PR TITLE
Pass HTMLAttributes to props

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -67,9 +67,19 @@ export interface EditorProps {
    * IEditorOverrideServices
    */
   overrideServices?: monacoEditor.editor.IEditorOverrideServices;
+
+  /**
+   * Class name for the editor container
+   */
+  className?: string;
+
+  /**
+   * Class name for the editor container wrapper
+   */
+  wrapperClassName?: string;
 }
 
-declare const Editor: React.FC<EditorProps & React.HTMLAttributes<HTMLDivElement>>;
+declare const Editor: React.FC<EditorProps>;
 
 export default Editor;
 
@@ -90,7 +100,7 @@ export interface ControlledEditorProps extends EditorProps {
   onChange?: ControlledEditorOnChange;
 }
 
-declare const ControlledEditor: React.FC<ControlledEditorProps & React.HTMLAttributes<HTMLDivElement>>;
+declare const ControlledEditor: React.FC<ControlledEditorProps>;
 
 export { ControlledEditor };
 
@@ -168,9 +178,19 @@ export interface DiffEditorProps {
    * IDiffEditorConstructionOptions
    */
   options?: monacoEditor.editor.IDiffEditorConstructionOptions;
+
+  /**
+   * Class name for the editor container
+   */
+  className?: string;
+
+  /**
+   * Class name for the editor container wrapper
+   */
+  wrapperClassName?: string;
 }
 
-declare const DiffEditor: React.FC<DiffEditorProps & React.HTMLAttributes<HTMLDivElement>>;
+declare const DiffEditor: React.FC<DiffEditorProps>;
 
 export { DiffEditor };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,7 +69,7 @@ export interface EditorProps {
   overrideServices?: monacoEditor.editor.IEditorOverrideServices;
 }
 
-declare const Editor: React.FC<EditorProps>;
+declare const Editor: React.FC<EditorProps & React.HTMLAttributes<HTMLDivElement>>;
 
 export default Editor;
 
@@ -90,7 +90,7 @@ export interface ControlledEditorProps extends EditorProps {
   onChange?: ControlledEditorOnChange;
 }
 
-declare const ControlledEditor: React.FC<ControlledEditorProps>;
+declare const ControlledEditor: React.FC<ControlledEditorProps & React.HTMLAttributes<HTMLDivElement>>;
 
 export { ControlledEditor };
 
@@ -170,7 +170,7 @@ export interface DiffEditorProps {
   options?: monacoEditor.editor.IDiffEditorConstructionOptions;
 }
 
-declare const DiffEditor: React.FC<DiffEditorProps>;
+declare const DiffEditor: React.FC<DiffEditorProps & React.HTMLAttributes<HTMLDivElement>>;
 
 export { DiffEditor };
 


### PR DESCRIPTION
Adds `React.HTMLAttributes<HTMLDivElements>>` to the the Functional Component type.

Fixes below issue when using `className` with TypeScript.

![image](https://user-images.githubusercontent.com/32042602/93809628-65dac300-fc45-11ea-8144-8524a15edcc3.png)