### PR TITLE
Exposed monacoRef for Full API Access 

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can play with it [here](https://codesandbox.io/s/monaco-editor-react-u0fyv?f
 
 #### Get Value
 
-You may ask how we can get the value of the editor. There is a prop called `editorDidMount`. It gets two arguments: the first one is a function to get editor value, the second one is the editor instance.
+You may ask how we can get the value of the editor. There is a prop called `editorDidMount`. It gets three arguments: the first one is a function to get editor value, the second one is the editor instance, the third one is the monaco instance.
 Here is an example of how you can implement it.
 You can play with it [here](https://codesandbox.io/s/example-for-issue-2-1hzz8?fontsize=14)
 
@@ -471,7 +471,7 @@ You can play with the example [here](https://codesandbox.io/s/create-your-own-ed
 |:----------|:-------------|:------|:------|
 | value | string || The editor value |
 | language | enum: ... | | All languages that are [supported](https://github.com/microsoft/monaco-languages) by monaco-editor |
-| editorDidMount | func | noop | **Signature: function(getEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a second argument |
+| editorDidMount | func | noop | **Signature: function(getEditorValue: func, editor: object, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a second argument |
 | theme | enum: 'light' \| 'dark' | 'light' | Default themes of monaco |
 | line | number |  | The line to jump on it |
 | width | union: number \| string | '100%' | The width of the editor wrapper |
@@ -490,7 +490,7 @@ You can play with the example [here](https://codesandbox.io/s/create-your-own-ed
 | language | enum: ... | | All languages that are [supported](https://github.com/microsoft/monaco-languages) by monaco-editor |
 | originalLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the `original` source separately, otherwise, it will get the value of `language` property. (Possible values are the same as `language`) |
 | modifiedLanguage | enum: ... | *language | This prop gives you the opportunity to specify the language of the `modified` source separately, otherwise, it will get the value of `language` property. (Possible values are the same as `language`) |
-| editorDidMount | func | noop | **Signature: function(getModifiedEditorValue: func, getOriginalEditorValue: func, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a third argument |
+| editorDidMount | func | noop | **Signature: function(getModifiedEditorValue: func, getOriginalEditorValue: func, editor: object, monaco: object) => void** <br/> This function will be called right after monaco editor is mounted and is ready to work. It will get the editor instance as a third argument |
 | theme | enum: 'light' \| 'dark' | 'light' | Default themes of monaco |
 | width | union: number \| string | '100%' | The width of the editor wrapper |
 | height | union: number \| string | '100%' | The height of the editor wrapper |

--- a/src/ControlledEditor/ControlledEditor.js
+++ b/src/ControlledEditor/ControlledEditor.js
@@ -6,6 +6,7 @@ import { noop } from '../utils';
 
 function ControlledEditor({ value: providedValue, onChange, editorDidMount, ...props }) {
   const editor = useRef(null);
+  const monaco = useRef(null);
   const listener = useRef(null);
   const value = useRef(providedValue);
 
@@ -36,11 +37,12 @@ function ControlledEditor({ value: providedValue, onChange, editorDidMount, ...p
     return () => listener.current?.dispose();
   }, [attachChangeEventListener]);
 
-  const handleEditorDidMount = useCallback((getValue, _editor) => {
+  const handleEditorDidMount = useCallback((getValue, _editor, _monaco) => {
     editor.current = _editor;
+    monaco.current = _monaco;
     attachChangeEventListener();
 
-    editorDidMount(getValue, _editor);
+    editorDidMount(getValue, _editor, _monaco);
   }, [attachChangeEventListener, editorDidMount]);
 
   return (

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -87,7 +87,7 @@ const Editor = ({
       ...options,
     }, overrideServices);
 
-    editorDidMount(editorRef.current.getValue.bind(editorRef.current), editorRef.current);
+    editorDidMount(editorRef.current.getValue.bind(editorRef.current), editorRef.current, monacoRef.current);
 
     monacoRef.current.editor.defineTheme('dark', themes['night-dark']);
     monacoRef.current.editor.setTheme(theme);


### PR DESCRIPTION
Exposed monacoRef through editorDidMount to allow users to access full Monaco API.

Please let me know if this is okay or if you believe there is a better way of doing this. I would like to be able to access the full Monaco API so that I can use the built in marker validation to check if the user's code matches the language schema.

I am mainly using this to access getModelMarkers but can see how full on the fly access could help in the future for more customization.
https://microsoft.github.io/monaco-editor/api/modules/monaco.editor.html#getmodelmarkers

This would solve #132

Let me know if there is an existing way to access that data. I searched through the existing editorRef and could not find the functions I needed.