### PR TITLE
Update index.d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ You can play with the example [here](https://codesandbox.io/s/create-your-own-ed
 | width | union: number \| string | '100%' | The width of the editor wrapper |
 | height | union: number \| string | '100%' | The height of the editor wrapper |
 | loading | union: React element \| string | 'Loading...' | The loading screen before the editor is loaded |
-| options | object | {} | [IEditorOptions](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html) |
+| options | object | {} | [IStandaloneEditorConstructionOptions](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html) |
 | className | string || monaco container className |
 | wrapperClassName | string || monaco container wrapper className |
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,9 +59,9 @@ export interface EditorProps {
   loading?: React.ReactNode;
 
   /**
-   * IEditorConstructionOptions
+   * IStandaloneEditorConstructionOptions
    */
-  options?: monacoEditor.editor.IEditorConstructionOptions;
+  options?: monacoEditor.editor.IStandaloneEditorConstructionOptions;
 
   /**
    * IEditorOverrideServices


### PR DESCRIPTION
the type for options seems to be not right.

<img width="755" alt="Screen Shot 2020-12-25 at 0 08 52" src="https://user-images.githubusercontent.com/2394070/103095845-63717600-4645-11eb-950a-d7e91812b7a8.png">

`IStandaloneEditorConstructionOptions` is actually used in `create()`,

<img width="841" alt="Screen Shot 2020-12-25 at 0 08 46" src="https://user-images.githubusercontent.com/2394070/103095867-74ba8280-4645-11eb-8357-d0d1b276d141.png">

which includes `IGlobalEditorOptions` . 


I wanted to adjust `tabSize` and found this problem