### PR TITLE
add types path on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Suren Atoyan <contact@surenatoyan.com>",
   "main": "lib/cjs/index.js",
   "module": "lib/es/index.js",
+  "types": "lib/index.d.ts",
   "unpkg": "lib/umd/monaco-react.min.js",
   "jsdelivr": "lib/umd/monaco-react.min.js",
   "scripts": {


### PR DESCRIPTION
Add the `types` field to package.json so that the editor can read the type file properly

reference: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html