### PR TITLE
issue: #185: use revealLine for line update

### DIFF
--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -103,7 +103,7 @@ function Editor({
   }, [language], isEditorReady);
 
   useUpdate(() => {
-    editorRef.current.setScrollPosition({ scrollTop: line });
+    editorRef.current.revealLine(line);
   }, [line], isEditorReady);
 
   useUpdate(() => {


### PR DESCRIPTION
This PR fixes https://github.com/suren-atoyan/monaco-react/issues/185

The solution was to use `revealLine` instead of `setScrollPosition` (which works with pixel values instead of line)
Also as it turns out, there are 3 methods: `revealLine`, `revealLineInCenter` and `revealLineNearTop`. I'm not sure if it's a good idea to add this complexityto `Editor`'s props or to choose a different default behavior for `monaco-react` library.