### PR TITLE
validate property `line` before passing it to `revealLine`

### DIFF
--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -7,7 +7,7 @@ import MonacoContainer from '../MonacoContainer';
 import useMount from '../hooks/useMount';
 import useUpdate from '../hooks/useUpdate';
 import usePrevious from '../hooks/usePrevious';
-import { noop, getOrCreateModel } from '../utils';
+import { noop, getOrCreateModel, isUndefined } from '../utils';
 
 const [getModelMarkersSetter, setModelMarkersSetter] = state.create({
   backup: null,
@@ -103,7 +103,10 @@ function Editor({
   }, [language], isEditorReady);
 
   useUpdate(() => {
-    editorRef.current.revealLine(line);
+    // reason for undefined check: https://github.com/suren-atoyan/monaco-react/pull/188
+    if(!isUndefined(line)) {
+      editorRef.current.revealLine(line);
+    }
   }, [line], isEditorReady);
 
   useUpdate(() => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,4 +20,8 @@ function crateModelUri(monaco, path) {
   return monaco.Uri.parse(path);
 }
 
-export { noop, getOrCreateModel };
+function isUndefined(input) {
+  return input === undefined;
+}
+
+export { noop, getOrCreateModel, isUndefined };


### PR DESCRIPTION
Hey there! In my last PR I did not test something, that it was my actual use case. The so-called `autoScroll` functionality I told you about is toggle-able. This is the demo of the problem I had with `4.0.10`. Sorry for the mistake :rose: 

https://codesandbox.io/s/xenodochial-allen-hb2k6?file=/src/App.js

In this codeSandBox, when I click on `toggle AutoScroll` button, `undefined` is passed to `line` property and  the app crashes. 

I believe we do not need to check for other data types (e.g. `string`, `null`, `object`, etc...) as it is already documented in documentation of the library that the type of `line` property is `number`. But alongside every property in React, there lies implicitly an `undefined` value that is like when the property is not specified at all

This PR checks for `undefined`