### PR TITLE
add `keepCurrentOriginalModel` and `keepCurrentModifiedModel` properties; indicator whether to dispose the current original/modified model when the DiffEditor is unmounted or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Versions
 
+## 4.1.2
+###### *Apr 19, 2021*
+
+- DiffEditor: add `keepCurrentOriginalModel` and `keepCurrentModifiedModel` properties; indicator whether to dispose the current original/modified model when the DiffEditor is unmounted or not
+- package.json: update monaco-editor peerDependency to the lates one (0.23.0)
+
 ## 4.1.1
 ###### *Apr 2, 2021*
 

--- a/README.md
+++ b/README.md
@@ -763,6 +763,8 @@ If you want to change something in the library, go to `monaco-react/src/...`, th
 | modifiedLanguage | enum: ... | | This prop gives you the opportunity to specify the language of the modified source separately, otherwise, it will get the value of language property |
 | originalModelPath | string || Path for the "original" model. Will be passed as a third argument to `.createModel` method - `monaco.editor.createModel(..., ..., monaco.Uri.parse(originalModelPath))` |
 | modifiedModelPath | string || Path for the "modified" model. Will be passed as a third argument to `.createModel` method - `monaco.editor.createModel(..., ..., monaco.Uri.parse(modifiedModelPath))` |
+| keepCurrentOriginalModel | boolean | false | Indicator whether to dispose the current original model when the DiffEditor is unmounted or not |
+| keepCurrentModifiedModel | boolean | false | Indicator whether to dispose the current modified model when the DiffEditor is unmounted or not |
 | theme | enum: "light" \| "vs-dark" | "light" | The theme for the monaco. Available options "vs-dark" \| "light". Define new themes by `monaco.editor.defineTheme` |
 | line | number |  | The line to jump on it |
 | loading | React Node | "Loading..." | The loading screen before the editor will be mounted

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-editor/react",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Monaco Editor for React - use the monaco-editor in any React application without needing to use webpack (or rollup/parcel/etc) configuration files / plugins",
   "author": "Suren Atoyan <contact@surenatoyan.com>",
   "main": "lib/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/suren-atoyan/monaco-react#readme",
   "peerDependencies": {
-    "monaco-editor": "^0.21.2",
+    "monaco-editor": "^0.23.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },

--- a/src/DiffEditor/DiffEditor.js
+++ b/src/DiffEditor/DiffEditor.js
@@ -16,6 +16,8 @@ function DiffEditor ({
   /* === */
   originalModelPath,
   modifiedModelPath,
+  keepCurrentOriginalModel,
+  keepCurrentModifiedModel,
   theme,
   loading,
   options,
@@ -128,10 +130,17 @@ function DiffEditor ({
     !isMonacoMounting && !isEditorReady && createEditor();
   }, [isMonacoMounting, isEditorReady, createEditor]);
 
-  const disposeEditor = () => {
+  function disposeEditor() {
     const models = editorRef.current.getModel();
-    models.original?.dispose();
-    models.modified?.dispose();
+
+    if (!keepCurrentOriginalModel) {
+      models.original?.dispose();
+    }
+
+    if (!keepCurrentModifiedModel) {
+      models.modified?.dispose();
+    }
+
     editorRef.current.dispose();
   }
 
@@ -157,6 +166,8 @@ DiffEditor.propTypes = {
   /* === */
   originalModelPath: PropTypes.string,
   modifiedModelPath: PropTypes.string,
+  keepCurrentOriginalModel: PropTypes.bool,
+  keepCurrentModifiedModel: PropTypes.bool,
   theme: PropTypes.string,
   loading: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.object,
@@ -174,6 +185,8 @@ DiffEditor.defaultProps = {
   theme: 'light',
   loading: 'Loading...',
   options: {},
+  keepCurrentOriginalModel: false,
+  keepCurrentModifiedModel: false,
   /* === */
   width: '100%',
   height: '100%',


### PR DESCRIPTION
- DiffEditor: add `keepCurrentOriginalModel` and `keepCurrentModifiedModel` properties; indicator whether to dispose the current original/modified model when the DiffEditor is unmounted or not
- package.json: update monaco-editor peerDependency to the lates one (0.23.0)