### PR TITLE
Add overflow: hidden to the default wrapper styles

### DIFF
--- a/src/MonacoContainer/styles.js
+++ b/src/MonacoContainer/styles.js
@@ -3,6 +3,7 @@ const styles = {
     display: 'flex',
     position: 'relative',
     textAlign: 'initial',
+    overflow: 'hidden',
   },
   fullWidth: {
     width: '100%',


### PR DESCRIPTION
It's obviously just a proposal - I've worked around my problem using `wrapperClassName` prop.

I can't find a strong argument against adding this - maybe you would have one. It seems to me that this is the expected behavior in the vast majority of scenarios. In fact, I don't think that anything in the editor itself can actually overflow this container... but Monaco creates a fixed-size element that gets resized based on this wrapper and the internal `ResizeObserver`. This makes certain layouts (like specific grids) break when resizing the viewport because the wrapper doesn't always change its size with that. The fixed-size element inside might cause the grid cell to stretch beyond what has been "reserved" for it - this SO answer contains more details about the behavior: https://stackoverflow.com/questions/43311943/prevent-content-from-expanding-grid-items/43312314#43312314 

So it seems to me that this shouldn't actually break any usage in the wild while making certain grid layouts (and flex ones as well) working better out of the box.