### PR TITLE
Fix small typo in Demo project

### DIFF
--- a/demo/src/sections/Editor/Settings/Settings.js
+++ b/demo/src/sections/Editor/Settings/Settings.js
@@ -52,10 +52,10 @@ const Settings = _ => {
 
   function handleApply() {
     const currentValue = getEditorValue();
-    let oprions;
+    let options;
     try {
-      oprions = JSON.parse(currentValue);
-      setOptions(oprions);
+      options = JSON.parse(currentValue);
+      setOptions(options);
     } catch {
       showNotification({
         message: config.messages.invalidOptions,


### PR DESCRIPTION
Change "oprions" to correct variable name - "options"