### PR TITLE
adding callback to run custom logic right after monaco is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ If you want to change something in the library, go to `monaco-react/src/...`, th
 | onMount | func | noop | **Signature: function(editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) => void** <br/> An event is emitted when the editor is mounted. It gets the `editor` instance as a first argument and the `monaco` instance as a second|
 | onChange | func || **Signature: function(value: string \| undefined, ev: monaco.editor.IModelContentChangedEvent) => void** <br/> An event is emitted when the content of the current model is changed|
 | onValidate | func | noop | **Signature: function(markers: monaco.editor.IMarker[]) => void** <br/> An event is emitted when the content of the current model is changed and the current model markers are ready|
+| onEditorModuleLoaded | func | noop | **Signature: function(monaco: Monaco) => void** <br/> An event is emitted immediately after the editor module (monaco) is loaded. It gets the `monaco` instance as a first argument|
 
 #### `DiffEditor`
 
@@ -832,6 +833,7 @@ If you want to change something in the library, go to `monaco-react/src/...`, th
 | wrapperProps | object | {} | Props applied to the wrapper element |
 | beforeMount | func | noop | **Signature: function(monaco: Monaco) => void** <br/> An event is emitted before the editor mounted. It gets the `monaco` instance as a first argument|
 | onMount | func | noop | **Signature: function(editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) => void** <br/> An event is emitted when the editor is mounted. It gets the `editor` instance as a first argument and the `monaco` instance as a second|
+| onEditorModuleLoaded | func | noop | **Signature: function(monaco: Monaco) => void** <br/> An event is emitted immediately after the editor module (monaco) is loaded. It gets the `monaco` instance as a first argument|
 
 ## License
 

--- a/src/DiffEditor/DiffEditor.js
+++ b/src/DiffEditor/DiffEditor.js
@@ -29,6 +29,7 @@ function DiffEditor ({
   /* === */
   beforeMount,
   onMount,
+  onEditorModuleLoaded,
 }) {
   const [isEditorReady, setIsEditorReady] = useState(false);
   const [isMonacoMounting, setIsMonacoMounting] = useState(true);
@@ -37,12 +38,18 @@ function DiffEditor ({
   const containerRef = useRef(null);
   const onMountRef = useRef(onMount);
   const beforeMountRef = useRef(beforeMount);
+  const onEditorModuleLoadedRef = useRef(onEditorModuleLoaded);
+
 
   useMount(() => {
     const cancelable = loader.init();
 
     cancelable
-      .then(monaco => ((monacoRef.current = monaco) && setIsMonacoMounting(false)))
+      .then(monaco => {
+        monacoRef.current = monaco;
+        onEditorModuleLoadedRef.current(monaco);
+        setIsMonacoMounting(false);
+      })
       .catch(error => error?.type !== 'cancelation' &&
         console.error('Monaco initialization: error:', error));
 
@@ -179,6 +186,7 @@ DiffEditor.propTypes = {
   /* === */
   beforeMount: PropTypes.func,
   onMount: PropTypes.func,
+  onEditorModuleLoaded: PropTypes.func,
 };
 
 DiffEditor.defaultProps = {
@@ -194,6 +202,7 @@ DiffEditor.defaultProps = {
   /* === */
   beforeMount: noop,
   onMount: noop,
+  onEditorModuleLoaded: noop,
 };
 
 export default DiffEditor;

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -35,6 +35,7 @@ function Editor({
   onMount,
   onChange,
   onValidate,
+  onEditorModuleLoaded,
 }) {
   const [isEditorReady, setIsEditorReady] = useState(false);
   const [isMonacoMounting, setIsMonacoMounting] = useState(true);
@@ -43,6 +44,7 @@ function Editor({
   const containerRef = useRef(null);
   const onMountRef = useRef(onMount);
   const beforeMountRef = useRef(beforeMount);
+  const onEditorModuleLoadedRef = useRef(onEditorModuleLoaded);
   const subscriptionRef = useRef(null);
   const valueRef = useRef(value);
   const previousPath = usePrevious(path);
@@ -52,7 +54,11 @@ function Editor({
     const cancelable = loader.init();
 
     cancelable
-      .then(monaco => ((monacoRef.current = monaco) && setIsMonacoMounting(false)))
+      .then(monaco => {
+        monacoRef.current = monaco;
+        onEditorModuleLoadedRef.current(monaco);
+        setIsMonacoMounting(false);
+      })
       .catch(error => error?.type !== 'cancelation' &&
         console.error('Monaco initialization: error:', error));
 
@@ -245,6 +251,7 @@ Editor.propTypes = {
   onMount: PropTypes.func,
   onChange: PropTypes.func,
   onValidate: PropTypes.func,
+  onEditorModuleLoaded: PropTypes.func,
 };
 
 Editor.defaultProps = {
@@ -262,6 +269,7 @@ Editor.defaultProps = {
   beforeMount: noop,
   onMount: noop,
   onValidate: noop,
+  onEditorModuleLoaded: noop,
 };
 
 export default Editor;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -30,6 +30,10 @@ export type OnValidate = (
   markers: monaco.editor.IMarker[],
 ) => void;
 
+export type OnEditorModuleLoaded =  (
+  monaco: Monaco,
+) => void;
+
 export interface EditorProps {
   /**
    * Default value of the current model
@@ -157,6 +161,14 @@ export interface EditorProps {
    * Defaults to "noop"
    */
   onValidate?: OnValidate;
+
+    /**
+   * Signature: function(monaco: Monaco) => void
+   * An event is emitted immediately after editor module (monaco) is loaded
+   * It gets the monaco instance as a first argument
+   * Defaults to "noop"
+   */
+  onEditorModuleLoaded?: OnEditorModuleLoaded;
 }
 
 declare const Editor: React.FC<EditorProps>;
@@ -171,6 +183,10 @@ export type DiffOnMount = (
 ) => void;
 
 export type DiffBeforeMount = (
+  monaco: Monaco,
+) => void;
+
+export type DiffOnEditorModuleLoaded =  (
   monaco: Monaco,
 ) => void;
 
@@ -282,6 +298,14 @@ export interface DiffEditorProps {
    * Defaults to "noop"
    */
   onMount?: DiffOnMount;
+
+  /**
+   * Signature: function(monaco: Monaco) => void
+   * An event is emitted immediately after editor module (monaco) is loaded
+   * It gets the monaco instance as a first argument
+   * Defaults to "noop"
+   */
+  onEditorModuleLoaded?: DiffOnEditorModuleLoaded;
 }
 
 declare const DiffEditor: React.FC<DiffEditorProps>;


### PR DESCRIPTION
This pr adds a callback prop to run custom logic immediately after monaco is loaded and loader.init() finishes. 