### PR TITLE
track model usage, and only dispose when not used

### DIFF
--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -6,7 +6,7 @@ import MonacoContainer from '../MonacoContainer';
 import useMount from '../hooks/useMount';
 import useUpdate from '../hooks/useUpdate';
 import usePrevious from '../hooks/usePrevious';
-import { noop, getOrCreateModel, isUndefined } from '../utils';
+import { noop, getOrCreateModel, isUndefined, disposeModel } from '../utils';
 
 const viewStates = new Map();
 
@@ -69,6 +69,9 @@ function Editor({
 
     if (model !== editorRef.current.getModel()) {
       saveViewState && viewStates.set(previousPath, editorRef.current.saveViewState());
+      if (!keepCurrentModel) {
+        disposeModel(editorRef.current.getModel())
+      }
       editorRef.current.setModel(model);
       saveViewState && editorRef.current.restoreViewState(viewStates.get(path));
     }
@@ -201,7 +204,7 @@ function Editor({
     if (keepCurrentModel) {
       saveViewState && viewStates.set(path, editorRef.current.saveViewState());
     } else {
-      editorRef.current.getModel()?.dispose();
+      disposeModel(editorRef.current.getModel());
     }
 
     editorRef.current.dispose();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,13 +1,19 @@
+import { decrementModelUsage, incrementModelUsage, shouldDisposeModel } from "./track-model-usage";
+
 function noop() {}
 
 function getOrCreateModel(monaco, value, language, path) {
-  return getModel(monaco, path) || createModel(monaco, value, language, path);
+  const uri = path && createModelUri(monaco, path);
+  const model = getModel(monaco, uri) || createModel(monaco, value, language, uri);
+  incrementModelUsage(model);
+
+  return model;
 }
 
-function getModel(monaco, path) {
+function getModel(monaco, uri) {
   return monaco
     .editor
-    .getModel(createModelUri(monaco, path));
+    .getModel(uri);
 }
 
 function createModel(monaco, value, language, path) {
@@ -24,4 +30,14 @@ function isUndefined(input) {
   return input === undefined;
 }
 
-export { noop, getOrCreateModel, isUndefined };
+function disposeModel(model) {
+  if (!model) {
+    return;
+  }
+  decrementModelUsage(model);
+  if (shouldDisposeModel(model)) {
+    model.dispose();
+  }
+}
+
+export { noop, getOrCreateModel, isUndefined, disposeModel };

--- a/src/utils/track-model-usage.js
+++ b/src/utils/track-model-usage.js
@@ -1,0 +1,22 @@
+
+const modelUsage = {};
+
+function decrementModelUsage(model) {
+  if (modelUsage[model.uri]) {
+    modelUsage[model.uri] -= 1;
+  }
+}
+
+function incrementModelUsage(model) {
+  const uri = model.uri;
+  if (modelUsage[uri] == null) {
+    modelUsage[uri] = 0;
+  }
+  modelUsage[uri] = modelUsage[uri] + 1;
+}
+
+function shouldDisposeModel(model) {
+  return !modelUsage[model.uri] || modelUsage[model.uri] == null;
+}
+
+export { decrementModelUsage, incrementModelUsage, shouldDisposeModel };


### PR DESCRIPTION
### Problem 

During the unmount, it was possible to dispose of the model used by the other editor instances. Disposing of the model of the existing editor will break the editor without any errors. See bug report #417 
 
### Solution

To prevent that, I have added tracking of model usage, and only disposing of model when it's not used by any other editor instances.