### PR TITLE
Expose types from monaco namespace

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,6 +11,8 @@ type Theme =
 // monaco
 export type Monaco = typeof monaco;
 
+export { monaco }
+
 // Editor
 export type OnMount = (
   editor: monaco.editor.IStandaloneCodeEditor,


### PR DESCRIPTION
I would like to access original types in the Monaco namespace for using them in a custom code completion, e.g. monaco.languages.CompletionItem.

The `typeof` in the [existing export](https://github.com/suren-atoyan/monaco-react/blob/master/src/types.d.ts#L12) does not seem to expose information in the exported namespaces.

I briefly checked the open [PR for switching to TS](https://github.com/suren-atoyan/monaco-react/pull/457) and from the code it looks, a similar export would be needed? 

This patch could be a quick intermediate step for making internal types available to the outside. What do you think? Or did I miss how to access the internal types with the existing export?