### PR TITLE
Make user styles work on the section container

### DIFF
--- a/src/MonacoContainer/MonacoContainer.js
+++ b/src/MonacoContainer/MonacoContainer.js
@@ -18,12 +18,11 @@ function MonacoContainer({
   wrapperProps,
 }) {
   return (
-    <section style={{ ...styles.wrapper, width, height }} {...wrapperProps}>
+    <section className={className} style={{ ...styles.wrapper, width, height }} {...wrapperProps}>
       {!isEditorReady && <Loading content={loading} />}
       <div
         ref={_ref}
         style={{ ...styles.fullWidth, ...(!isEditorReady && styles.hide) }}
-        className={className}
       />
     </section>
   );


### PR DESCRIPTION
Target the base section element so that users can change the width/height and positioning to the section instead of the monaco editor

Reference issue: https://github.com/suren-atoyan/monaco-react/issues/468