### PR TITLE
DiffEditor fix: set correct model before value update

### DIFF
--- a/src/DiffEditor/DiffEditor.tsx
+++ b/src/DiffEditor/DiffEditor.tsx
@@ -4,7 +4,7 @@ import loader from '@monaco-editor/loader';
 import MonacoContainer from '../MonacoContainer';
 import useMount from '../hooks/useMount';
 import useUpdate from '../hooks/useUpdate';
-import { noop, getOrCreateModel } from '../utils';
+import { noop, getOrCreateModel, getModel } from '../utils';
 import { type DiffEditorProps, type MonacoDiffEditor } from './types';
 import { type Monaco } from '..';
 
@@ -53,6 +53,12 @@ function DiffEditor({
   useUpdate(
     () => {
       const modifiedEditor = editorRef.current!.getModifiedEditor();
+      if (keepCurrentModifiedModel && modifiedModelPath) {
+        const model = getModel(monacoRef.current!, modifiedModelPath);
+        if (model !== modifiedEditor.getModel()) {
+          modifiedEditor.setModel(model);
+        }
+      }
       if (modifiedEditor.getOption(monacoRef.current!.editor.EditorOption.readOnly)) {
         modifiedEditor.setValue(modified || '');
       } else {
@@ -69,15 +75,23 @@ function DiffEditor({
         }
       }
     },
-    [modified],
+    [modified, modifiedModelPath, keepCurrentModifiedModel],
     isEditorReady,
   );
 
   useUpdate(
     () => {
-      editorRef.current?.getModel()?.original.setValue(original || '');
+      const originalEditor = editorRef.current!.getOriginalEditor();
+      if (keepCurrentOriginalModel && originalModelPath) {
+        const model = getModel(monacoRef.current!, originalModelPath);
+        if (model !== editorRef.current!.getModel()) {
+          originalEditor.setModel(model);
+        }
+      }
+
+      originalEditor.setValue(original || '');
     },
-    [original],
+    [original, originalModelPath, keepCurrentOriginalModel],
     isEditorReady,
   );
 

--- a/src/DiffEditor/DiffEditor.tsx
+++ b/src/DiffEditor/DiffEditor.tsx
@@ -165,6 +165,46 @@ function DiffEditor({
     !isMonacoMounting && !isEditorReady && createEditor();
   }, [isMonacoMounting, isEditorReady, createEditor]);
 
+  useUpdate(
+    () => {
+      if (editorRef.current && monacoRef.current) {
+        const originalEditor = editorRef.current.getOriginalEditor();
+        const model = getOrCreateModel(
+          monacoRef.current,
+          original || '',
+          originalLanguage || language || 'text',
+          originalModelPath || '',
+        );
+
+        if (model !== originalEditor.getModel()) {
+          originalEditor.setModel(model);
+        }
+      }
+    },
+    [originalModelPath],
+    isEditorReady,
+  );
+
+  useUpdate(
+    () => {
+      if (editorRef.current && monacoRef.current) {
+        const modifiedEditor = editorRef.current.getModifiedEditor();
+        const model = getOrCreateModel(
+          monacoRef.current,
+          modified || '',
+          modifiedLanguage || language || 'text',
+          modifiedModelPath || '',
+        );
+
+        if (model !== modifiedEditor.getModel()) {
+          modifiedEditor.setModel(model);
+        }
+      }
+    },
+    [modifiedModelPath],
+    isEditorReady,
+  );
+
   function disposeEditor() {
     const models = editorRef.current?.getModel();
 

--- a/src/DiffEditor/DiffEditor.tsx
+++ b/src/DiffEditor/DiffEditor.tsx
@@ -4,7 +4,7 @@ import loader from '@monaco-editor/loader';
 import MonacoContainer from '../MonacoContainer';
 import useMount from '../hooks/useMount';
 import useUpdate from '../hooks/useUpdate';
-import { noop, getOrCreateModel, getModel } from '../utils';
+import { noop, getOrCreateModel } from '../utils';
 import { type DiffEditorProps, type MonacoDiffEditor } from './types';
 import { type Monaco } from '..';
 
@@ -53,12 +53,6 @@ function DiffEditor({
   useUpdate(
     () => {
       const modifiedEditor = editorRef.current!.getModifiedEditor();
-      if (keepCurrentModifiedModel && modifiedModelPath) {
-        const model = getModel(monacoRef.current!, modifiedModelPath);
-        if (model !== modifiedEditor.getModel()) {
-          modifiedEditor.setModel(model);
-        }
-      }
       if (modifiedEditor.getOption(monacoRef.current!.editor.EditorOption.readOnly)) {
         modifiedEditor.setValue(modified || '');
       } else {
@@ -75,23 +69,15 @@ function DiffEditor({
         }
       }
     },
-    [modified, modifiedModelPath, keepCurrentModifiedModel],
+    [modified],
     isEditorReady,
   );
 
   useUpdate(
     () => {
-      const originalEditor = editorRef.current!.getOriginalEditor();
-      if (keepCurrentOriginalModel && originalModelPath) {
-        const model = getModel(monacoRef.current!, originalModelPath);
-        if (model !== editorRef.current!.getModel()) {
-          originalEditor.setModel(model);
-        }
-      }
-
-      originalEditor.setValue(original || '');
+      editorRef.current?.getModel()?.original.setValue(original || '');
     },
-    [original, originalModelPath, keepCurrentOriginalModel],
+    [original],
     isEditorReady,
   );
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -59,4 +59,4 @@ function createModelUri(monaco: Monaco, path: string) {
   return monaco.Uri.parse(path);
 }
 
-export { noop, getOrCreateModel, getModel };
+export { noop, getOrCreateModel };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -59,4 +59,4 @@ function createModelUri(monaco: Monaco, path: string) {
   return monaco.Uri.parse(path);
 }
 
-export { noop, getOrCreateModel };
+export { noop, getOrCreateModel, getModel };


### PR DESCRIPTION
When trying to keep the models in the `DiffEditor` the code sometimes updated the incorrect model with the incorrect value because it assumes the correct model is loaded. This update checks and sets the correct model for the passed modelpath before allowing updates to be made.

This addresses the issue described in #478 