### PR TITLE
Original and Modified models set earlier

### DIFF
--- a/src/DiffEditor/DiffEditor.tsx
+++ b/src/DiffEditor/DiffEditor.tsx
@@ -52,6 +52,46 @@ function DiffEditor({
 
   useUpdate(
     () => {
+      if (editorRef.current && monacoRef.current) {
+        const originalEditor = editorRef.current.getOriginalEditor();
+        const model = getOrCreateModel(
+          monacoRef.current,
+          original || '',
+          originalLanguage || language || 'text',
+          originalModelPath || '',
+        );
+
+        if (model !== originalEditor.getModel()) {
+          originalEditor.setModel(model);
+        }
+      }
+    },
+    [originalModelPath],
+    isEditorReady,
+  );
+
+  useUpdate(
+    () => {
+      if (editorRef.current && monacoRef.current) {
+        const modifiedEditor = editorRef.current.getModifiedEditor();
+        const model = getOrCreateModel(
+          monacoRef.current,
+          modified || '',
+          modifiedLanguage || language || 'text',
+          modifiedModelPath || '',
+        );
+
+        if (model !== modifiedEditor.getModel()) {
+          modifiedEditor.setModel(model);
+        }
+      }
+    },
+    [modifiedModelPath],
+    isEditorReady,
+  );
+
+  useUpdate(
+    () => {
       const modifiedEditor = editorRef.current!.getModifiedEditor();
       if (modifiedEditor.getOption(monacoRef.current!.editor.EditorOption.readOnly)) {
         modifiedEditor.setValue(modified || '');
@@ -164,46 +204,6 @@ function DiffEditor({
   useEffect(() => {
     !isMonacoMounting && !isEditorReady && createEditor();
   }, [isMonacoMounting, isEditorReady, createEditor]);
-
-  useUpdate(
-    () => {
-      if (editorRef.current && monacoRef.current) {
-        const originalEditor = editorRef.current.getOriginalEditor();
-        const model = getOrCreateModel(
-          monacoRef.current,
-          original || '',
-          originalLanguage || language || 'text',
-          originalModelPath || '',
-        );
-
-        if (model !== originalEditor.getModel()) {
-          originalEditor.setModel(model);
-        }
-      }
-    },
-    [originalModelPath],
-    isEditorReady,
-  );
-
-  useUpdate(
-    () => {
-      if (editorRef.current && monacoRef.current) {
-        const modifiedEditor = editorRef.current.getModifiedEditor();
-        const model = getOrCreateModel(
-          monacoRef.current,
-          modified || '',
-          modifiedLanguage || language || 'text',
-          modifiedModelPath || '',
-        );
-
-        if (model !== modifiedEditor.getModel()) {
-          modifiedEditor.setModel(model);
-        }
-      }
-    },
-    [modifiedModelPath],
-    isEditorReady,
-  );
 
   function disposeEditor() {
     const models = editorRef.current?.getModel();


### PR DESCRIPTION
These 2 hooks need to happen before Original (line 188) and Modified (line 100) are updated  to make sure we are updating the right models. This fix is related to past pr #479

see existing editor still having the mode switching problem here: https://codesandbox.io/s/react-monaco-bug-vzgxt8?file=/src/App.js:888-1233