### PR TITLE
fix: make line prop works as expected

### DIFF
--- a/src/Editor/Editor.tsx
+++ b/src/Editor/Editor.tsx
@@ -168,6 +168,10 @@ function Editor({
 
       monacoRef.current.editor.setTheme(theme);
 
+      if (line !== undefined) {
+        editorRef.current.revealLine(line);
+      }
+
       setIsEditorReady(true);
       preventCreation.current = true;
     }
@@ -182,6 +186,7 @@ function Editor({
     overrideServices,
     saveViewState,
     theme,
+    line,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
fix: https://github.com/suren-atoyan/monaco-react/issues/367

the `line` prop in `Editor` will not take effect when the editor is mounted, it only works when the line prop changes, I think it doesn't do what the documentation expects.

here is a repo: https://codesandbox.io/s/monaco-react-line-prop-y7jvvd?file=/src/App.tsx