### PR TITLE
fix: avoid rerender on uncomparable

### DIFF
--- a/src/Editor/Editor.tsx
+++ b/src/Editor/Editor.tsx
@@ -32,7 +32,7 @@ function Editor({
   width = '100%',
   height = '100%',
   className,
-  wrapperProps = {},
+  wrapperProps,
   /* === */
   beforeMount = noop,
   onMount = noop,

--- a/src/MonacoContainer/MonacoContainer.tsx
+++ b/src/MonacoContainer/MonacoContainer.tsx
@@ -17,7 +17,7 @@ function MonacoContainer({
   wrapperProps,
 }: ContainerProps) {
   return (
-    <section style={{ ...styles.wrapper, width, height }} {...wrapperProps}>
+    <section style={{ ...styles.wrapper, width, height }} {...(wrapperProps ? wrapperProps : {})}>
       {!isEditorReady && <Loading>{loading}</Loading>}
       <div
         ref={_ref}

--- a/src/MonacoContainer/MonacoContainer.tsx
+++ b/src/MonacoContainer/MonacoContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React from 'react';
 
 import styles from './styles';
 import Loading from '../Loading';
@@ -6,8 +6,6 @@ import { type ContainerProps } from './types';
 
 // ** forwardref render functions do not support proptypes or defaultprops **
 // one of the reasons why we use a separate prop for passing ref instead of using forwardref
-
-const MemoLoading = memo(Loading);
 
 function MonacoContainer({
   width,
@@ -20,7 +18,7 @@ function MonacoContainer({
 }: ContainerProps) {
   return (
     <section style={{ ...styles.wrapper, width, height }} {...(wrapperProps ? wrapperProps : {})}>
-      {!isEditorReady && <MemoLoading>{loading}</MemoLoading>}
+      {!isEditorReady && <Loading>{loading}</Loading>}
       <div
         ref={_ref}
         style={{ ...styles.fullWidth, ...(!isEditorReady && styles.hide) }}

--- a/src/MonacoContainer/MonacoContainer.tsx
+++ b/src/MonacoContainer/MonacoContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import styles from './styles';
 import Loading from '../Loading';
@@ -6,6 +6,8 @@ import { type ContainerProps } from './types';
 
 // ** forwardref render functions do not support proptypes or defaultprops **
 // one of the reasons why we use a separate prop for passing ref instead of using forwardref
+
+const MemoLoading = memo(Loading);
 
 function MonacoContainer({
   width,
@@ -18,7 +20,7 @@ function MonacoContainer({
 }: ContainerProps) {
   return (
     <section style={{ ...styles.wrapper, width, height }} {...(wrapperProps ? wrapperProps : {})}>
-      {!isEditorReady && <Loading>{loading}</Loading>}
+      {!isEditorReady && <MemoLoading>{loading}</MemoLoading>}
       <div
         ref={_ref}
         style={{ ...styles.fullWidth, ...(!isEditorReady && styles.hide) }}


### PR DESCRIPTION
I used this editor on one of my projects, and I also used wdyr (https://github.com/welldone-software/why-did-you-render) to detect unnecessary render. Turns out **wrapperProps** has default object which causes uncomparable re-render every time a new editor is shown on the screen. 

Fixed by undefined as default **wrapperProps** value on parent components and only expand on the innermost `<section>` tag when it is actually used so that outer components does not render again.  
