### PR TITLE
Don't fallback to the empty string for language in the `DiffEditor` to give Monaco a chance to deduce the langauge from paths

### DIFF
--- a/src/DiffEditor/DiffEditor.tsx
+++ b/src/DiffEditor/DiffEditor.tsx
@@ -59,7 +59,7 @@ function DiffEditor({
         const model = getOrCreateModel(
           monacoRef.current,
           original || '',
-          originalLanguage || language || 'text',
+          originalLanguage || language || '',
           originalModelPath || '',
         );
 
@@ -79,7 +79,7 @@ function DiffEditor({
         const model = getOrCreateModel(
           monacoRef.current,
           modified || '',
-          modifiedLanguage || language || 'text',
+          modifiedLanguage || language || '',
           modifiedModelPath || '',
         );
 
@@ -127,8 +127,8 @@ function DiffEditor({
     () => {
       const { original, modified } = editorRef.current!.getModel()!;
 
-      monacoRef.current!.editor.setModelLanguage(original, originalLanguage || language || 'text');
-      monacoRef.current!.editor.setModelLanguage(modified, modifiedLanguage || language || 'text');
+      monacoRef.current!.editor.setModelLanguage(original, originalLanguage || language || '');
+      monacoRef.current!.editor.setModelLanguage(modified, modifiedLanguage || language || '');
     },
     [language, originalLanguage, modifiedLanguage],
     isEditorReady,
@@ -156,14 +156,14 @@ function DiffEditor({
     const originalModel = getOrCreateModel(
       monacoRef.current,
       original || '',
-      originalLanguage || language || 'text',
+      originalLanguage || language || '',
       originalModelPath || '',
     );
 
     const modifiedModel = getOrCreateModel(
       monacoRef.current,
       modified || '',
-      modifiedLanguage || language || 'text',
+      modifiedLanguage || language || '',
       modifiedModelPath || '',
     );
 


### PR DESCRIPTION
Because `originalLanguage` and `modifiedLanguage` fallback to `text` in `DiffEditor`, Monaco will treat the contents as `text` and never try to infer the language from `originalModelPath` and `modifiedModelPath`. In `Editor`, `language` [falls back to the empty string](https://github.com/suren-atoyan/monaco-react/blob/3327f3c368cb6d56c02f2df8a9d45177ce6f52e9/src/Editor/Editor.tsx#L73).

```tsx
// Does not detect TypeScript.
<DiffEditor
    original="const a = 1;"
    modified="const a = 2;"
    originalModelPath="file.ts"
    modifiedModelPath="file.ts"
/>

// Has no problem detecting TypeScript.
<Editor
    value="const a = 1;"
    path="file.ts"
/>
```

This change updates `DiffEditor` to match the behavior of `Editor`.