### PR TITLE
Activity adoption changes

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "monaco-editor": "^0.36.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.0-canary-5e0c951b-20250916",
+    "react-dom": "^19.2.0-canary-5e0c951b-20250916",
     "state-local": "^1.0.7"
   },
   "devDependencies": {

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,14 +1,17 @@
-import React from "react";
+import React, { useState, Activity } from 'react';
 
-import Editor from "../../dist";
+import Editor from '../../dist';
 
 function App() {
+  const [isVisible, setIsVisible] = useState(true);
+
   return (
-    <Editor
-      height="100vh"
-      defaultLanguage="javascript"
-      defaultValue="// some comment"
-    />
+    <div>
+      <button onClick={() => setIsVisible((v) => !v)}>{isVisible ? 'Hide' : 'Show'} Editor</button>
+      <Activity mode={isVisible ? 'visible' : 'hidden'}>
+        <Editor height="100vh" defaultLanguage="javascript" defaultValue="// some comment" />
+      </Activity>
+    </div>
   );
 }
 

--- a/src/Editor/Editor.tsx
+++ b/src/Editor/Editor.tsx
@@ -253,6 +253,10 @@ function Editor({
     }
 
     editorRef.current!.dispose();
+
+    editorRef.current = null;
+    preventCreation.current = false;
+    setIsEditorReady(false);
   }
 
   return (


### PR DESCRIPTION
[Activity](https://react.dev/reference/react/Activity) is a new React component that has recently been released on @canary and allows users to show/hide UI while preserving internal state. The current `Editor` component (and potentially others) are not compatible with `Activity` as certain refs are not disposed when effects are cleaned up. 

This PR demonstrates a potential fix for the `Editor` component. Note that I have not dug super deep into the code so this may present side effects that I am not aware of, the changes to the playground are only for testing as well.

Mentioned in issue #753