### PR TITLE
fix cursor jumping to top on left pane in diff editor

### DIFF
--- a/src/DiffEditor/DiffEditor.tsx
+++ b/src/DiffEditor/DiffEditor.tsx
@@ -117,7 +117,22 @@ function DiffEditor({
 
   useUpdate(
     () => {
-      editorRef.current?.getModel()?.original.setValue(original || '');
+      const originalEditor = editorRef.current!.getOriginalEditor();
+      if (originalEditor.getOption(monacoRef.current!.editor.EditorOption.readOnly)) {
+        originalEditor.setValue(original || '');
+      } else {
+        if (original !== originalEditor.getValue()) {
+          originalEditor.executeEdits('', [
+            {
+              range: originalEditor.getModel()!.getFullModelRange(),
+              text: original || '',
+              forceMoveMarkers: true,
+            },
+          ]);
+
+          originalEditor.pushUndoStop();
+        }
+      }
     },
     [original],
     isEditorReady,


### PR DESCRIPTION
when controlled, the original pane was just using setValue which resets the cursor position on every keystroke. just copied what modifiedEditor does using executeEdits so it preserves cursor state.